### PR TITLE
Remove env with secrets and provide example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,7 @@
-# File: .env.local
-# IMPORTANT: Never commit this file to Git! Add to .gitignore
+# Example environment configuration
 
-# OpenRouter API Key (get from https://openrouter.ai/keys)
-# ⚠️  REPLACE WITH YOUR NEW KEY AFTER REVOKING THE EXPOSED ONE
-OPENROUTER_API_KEY=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
+# OpenRouter API Key
+OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY
 
 # Model Configuration
 OPENROUTER_MODEL=deepseek/deepseek-r1-0528:free
@@ -17,15 +15,13 @@ FRONTEND_URL=https://griot-website.vercel.app
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=465
 EMAIL_SECURE=true
-# ⚠️  Use App Passwords for Gmail, not your regular password
 EMAIL_USER=your-chat@griotbot.com
-EMAIL_PASS=qjqb qrty zusa iojz
+EMAIL_PASS=your-email-password
 
 # Resend API Key (if using Resend for emails)
-# ⚠️  REPLACE WITH YOUR ACTUAL RESEND KEY
-RESEND_API_KEY=re_h3pStU31_5W5no6ex12oMSD35QHB1U7ZA
+RESEND_API_KEY=your-resend-api-key
 
-# JWT Secret for authentication (generate a secure random string)
+# JWT Secret for authentication
 JWT_SECRET=your-jwt-secret-here
 
 # Database URL (if using database features later)


### PR DESCRIPTION
## Summary
- remove `.env.local` from version control
- add `.env.example` with placeholder configuration

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68658245b9dc8332afcc4a06c5d8d7e1