### PR TITLE
Add environment validation for OPENROUTER_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ When deploying to Vercel, set the same environment variables in your project.
 Navigate to **Project Settings → Environment Variables** and add `OPENROUTER_API_KEY` along with any optional variables from `.env.local`.
 Vercel automatically configures `VERCEL_URL` in production.
 
+On startup the API checks that `OPENROUTER_API_KEY` is defined and throws an error if it isn't found, so be sure to set the key through Vercel's Environment Variables page.
+

--- a/api/chat.js
+++ b/api/chat.js
@@ -3,6 +3,9 @@
 // Fixed prompt formatting and added streaming response
 
 import { NextResponse } from 'next/server';
+import validateEnv from '../lib/validateEnv';
+
+validateEnv();
 
 export const config = {
   runtime: 'edge',

--- a/lib/validateEnv.js
+++ b/lib/validateEnv.js
@@ -1,0 +1,7 @@
+export default function validateEnv() {
+  if (!process.env.OPENROUTER_API_KEY) {
+    throw new Error(
+      'OPENROUTER_API_KEY is not set. Please add it in your environment or through Vercel\'s Environment Variables page.'
+    );
+  }
+}

--- a/pages/api/chat.js
+++ b/pages/api/chat.js
@@ -1,4 +1,7 @@
 // File: /pages/api/chat.js - Syntax Error Fixed
+import validateEnv from '../../lib/validateEnv';
+
+validateEnv();
 
 function createSystemPrompt(storytellerMode) {
   const baseRules = `


### PR DESCRIPTION
## Summary
- add a shared `validateEnv` helper that throws when `OPENROUTER_API_KEY` is missing
- call `validateEnv` at module load time for `api/chat.js` and `pages/api/chat.js`
- document this requirement in `README`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6867472b0b7483328912d9fc41ee909d